### PR TITLE
[FIX] Wrong repo links in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/felippe-regazio/felippe-regazio-blog.git"
+    "url": "git+https://github.com/felippe-regazio/1post.git"
   },
   "keywords": [
     "static",
@@ -24,7 +24,7 @@
   "author": "Felippe Regazio",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/felippe-regazio/felippe-regazio-blog/issues"
+    "url": "https://github.com/felippe-regazio/1post/issues"
   },
-  "homepage": "https://github.com/felippe-regazio/felippe-regazio-blog#readme"
+  "homepage": "https://github.com/felippe-regazio/1post#readme"
 }


### PR DESCRIPTION
All the GitHub links (repo, readme, issues) are going to the [static blog repo](https://github.com/felippe-regazio/felippe-regazio-blog).

Just fixing this links =)