### PR TITLE
Added blog_posted_by_hint to index to indicate author right on home page

### DIFF
--- a/template/template-index.html
+++ b/template/template-index.html
@@ -45,6 +45,7 @@
   <div class="pm-container">
     <h1>{{blog_title}}</h1>
     <h2 class="pm-text-primary pm-h4">{{blog_description}}</h2>
+    <span>{{blog_posted_by_hint}}<a href="{{blog_author_url}}" target="_blank" rel="noreferrer noopener">{{blog_author}}</a></span>
     <hr>
   
     <!-- Edit as yout want -->


### PR DESCRIPTION
First of all, thanks for the excellent package!

I added a feature to my own personal repository, and I thought that it might be a nice addition to the tool overall.

I felt that it would be great to have an indicator right on the home page to show who was the author of the blog. So, I added a line to show it. Here is how it looks like, visually speaking:
![Screenshot from 2023-11-13 23-49-09](https://github.com/felippe-regazio/1post/assets/98040112/b15b1ab6-98d1-4c44-a0e3-cc30a04a8b0c)

Of course, I'm not completely sure if this is a feature that is truly good to have on this tool, and I'm also not sure if my HTML is correct (I'm not a frontend dev and I know HTML is more complicated than it looks lol), so please, let me know if you want me to do any corrections/further explanations
